### PR TITLE
9 add ci support for building docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,9 +27,9 @@ jobs:
         TIMESTAMP=$(git show -s --format=%cI ${GITHUB_SHA})
         SHORT_TIME=$(echo $TIMESTAMP | sed 's/[-:]//g')
         TAG=spyderisk/system-modeller:$(echo ${GITHUB_REF} | sed 's/.*\///')-${SHORT_TIME:0:13}
-        docker build --tag $TAG --build-arg CI_COMMIT_SHA=${GITHUB_SHA} --build-arg CI_COMMIT_TIMESTAMP=${TIMESTAMP} --build-arg MAVEN_USER=${{ github.actor }} --build-arg MAVEN_PASS=${{ secrets.PACKAGE_READ_SECRET }} --file Dockerfile --target ssm-production "."
+        docker build --tag ${TAG} --build-arg CI_COMMIT_SHA=${GITHUB_SHA} --build-arg CI_COMMIT_TIMESTAMP=${TIMESTAMP} --build-arg MAVEN_USER=${{ github.actor }} --build-arg MAVEN_PASS=${{ secrets.PACKAGE_READ_SECRET }} --file Dockerfile --target ssm-production "."
 
     - name: Push Docker image to registry
       run: | 
         docker login -u spyderisk -p ${{ secrets.DOCKER_HUB_RW_SECRET }}
-        docker push 
+        docker push ${TAG}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,15 +2,16 @@ name: Docker Image CI
 
 on:
   workflow_run:
-    workflows: [Execute tests in docker-compose]
+    workflows: ["Execute tests in docker-compose"]
     types:
       - completed
+  workflow_dispatch:
 
 jobs:
 
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,17 +1,18 @@
 name: Docker Image CI
 
 on:
-  push:
-    branches: [ "dev",  "9-add-ci-support-for-building-docker-image" ]
-  pull_request:
-    branches: [ "dev",  "9-add-ci-support-for-building-docker-image" ]
-  workflow_dispatch:
+  workflow_run:
+    workflows: [Execute tests in docker-compose]
+    types:
+      - completed
 
 jobs:
 
   build:
 
     runs-on: ubuntu-20.04
+
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
     - name: Checkout
@@ -23,6 +24,10 @@ jobs:
       run: git lfs checkout
 
     - name: Build the Docker image
+      # The metadata inside the image will include the final git commit SHA and the time of the final commit.
+      # The tag applied to the image will be like spyderisk/system-modeller:<branch-name>-<timestamp>
+      # e.g. spyderisk/system-modeller:dev-20230405T1012
+      # Where the timestamp is the time of the final commit in the build.
       run: |
         TIMESTAMP=$(git show -s --format=%cI ${GITHUB_SHA})
         SHORT_TIME=$(echo $TIMESTAMP | sed 's/[-:]//g')

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,34 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "dev",  "9-add-ci-support-for-building-docker-image "]
+  pull_request:
+    branches: [ "dev",  "9-add-ci-support-for-building-docker-image "]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+
+    - name: LFS checkout
+      run: git lfs checkout
+
+    - name: Build the Docker image
+      run: |
+        TIMESTAMP=$(git show -s --format=%cI ${GITHUB_SHA})
+        SHORT_TIME=$(echo $TIMESTAMP | sed 's/[-:]//g')
+        TAG=spyderisk/system-modeller:$(echo ${GITHUB_REF} | sed 's/.*\///')-${SHORT_TIME:0:13}
+        docker build --tag $TAG --build-arg CI_COMMIT_SHA=${GITHUB_SHA} --build-arg CI_COMMIT_TIMESTAMP=${TIMESTAMP} --build-arg MAVEN_USER=${{ github.actor }} --build-arg MAVEN_PASS=${{ secrets.PACKAGE_READ_SECRET }} --file Dockerfile --target ssm-production "."
+
+    - name: Push Docker image to registry
+      run: | 
+        docker login -u spyderisk -p ${{ secrets.DOCKER_HUB_RW_SECRET }}
+        docker push 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,6 +27,7 @@ jobs:
         TIMESTAMP=$(git show -s --format=%cI ${GITHUB_SHA})
         SHORT_TIME=$(echo $TIMESTAMP | sed 's/[-:]//g')
         TAG=spyderisk/system-modeller:$(echo ${GITHUB_REF} | sed 's/.*\///')-${SHORT_TIME:0:13}
+        echo "TAG=${TAG}" >> ${GITHUB_ENV}
         docker build --tag ${TAG} --build-arg CI_COMMIT_SHA=${GITHUB_SHA} --build-arg CI_COMMIT_TIMESTAMP=${TIMESTAMP} --build-arg MAVEN_USER=${{ github.actor }} --build-arg MAVEN_PASS=${{ secrets.PACKAGE_READ_SECRET }} --file Dockerfile --target ssm-production "."
 
     - name: Push Docker image to registry

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "dev",  "9-add-ci-support-for-building-docker-image "]
+    branches: [ "dev",  "9-add-ci-support-for-building-docker-image" ]
   pull_request:
-    branches: [ "dev",  "9-add-ci-support-for-building-docker-image "]
+    branches: [ "dev",  "9-add-ci-support-for-building-docker-image" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,8 +31,9 @@ jobs:
       # Where the timestamp is the time of the final commit in the build.
       run: |
         TIMESTAMP=$(git show -s --format=%cI ${GITHUB_SHA})
-        SHORT_TIME=$(echo $TIMESTAMP | sed 's/[-:]//g')
-        TAG=spyderisk/system-modeller:$(echo ${GITHUB_REF} | sed 's/.*\///')-${SHORT_TIME:0:13}
+        SHORT_TIME=$(echo ${TIMESTAMP} | sed 's/[-:]//g')
+        REF_END=$(echo ${GITHUB_REF} | sed 's/.*\///')
+        TAG=spyderisk/system-modeller:${REF_END}-${SHORT_TIME:0:13}
         echo "TAG=${TAG}" >> ${GITHUB_ENV}
         docker build --tag ${TAG} --build-arg CI_COMMIT_SHA=${GITHUB_SHA} --build-arg CI_COMMIT_TIMESTAMP=${TIMESTAMP} --build-arg MAVEN_USER=${{ github.actor }} --build-arg MAVEN_PASS=${{ secrets.PACKAGE_READ_SECRET }} --file Dockerfile --target ssm-production "."
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "dev",  "9-add-ci-support-for-building-docker-image "]
   pull_request:
     branches: [ "dev",  "9-add-ci-support-for-building-docker-image "]
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
Adds a new workflow to build and push a docker image, which should trigger after the test workflow completes successfully.

It seems not possible to test this on a branch as it must exist on the default branch to work.