### PR TITLE
Replaces hard-coded username with variable

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,5 +39,5 @@ jobs:
 
     - name: Push Docker image to registry
       run: | 
-        docker login -u spyderisk -p ${{ secrets.DOCKER_HUB_RW_SECRET }}
+        docker login -u ${{ vars.DOCKER_HUB_USERNAME }} -p ${{ secrets.DOCKER_HUB_RW_SECRET }}
         docker push ${TAG}


### PR DESCRIPTION
To log in to Docker Hub so that the image can be pushed the workflow needs a username and password (or access token). It makes most sense to have the username as an organisation variable so that it can be changed easily.

Close #9 