### PR TITLE
#79: Set more user-friendly filename for asserted assets model export

### DIFF
--- a/src/main/java/uk/ac/soton/itinnovation/security/systemmodeller/rest/ModelController.java
+++ b/src/main/java/uk/ac/soton/itinnovation/security/systemmodeller/rest/ModelController.java
@@ -988,8 +988,8 @@ public class ModelController {
 		headers.add("Cache-Control", "no-cache, no-store, must-revalidate");
 		headers.add("Pragma", "no-cache");
 		headers.add("Expires", "0");
-		headers.add("Content-disposition", "attachment;filename=Model" + model.getId() + "_" +
-				(new SimpleDateFormat("yyyy-MM-dd_HH:mm:ss")).format(new Date()) + ".nq.gz");
+		headers.add("Content-disposition", "attachment;filename=" + model.getName() + " asserted " +
+				(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm")).format(new Date()) + ".nq.gz");
 		
 		//If we have temporarily invalidated the model above, reset the flag to true
 		if (resetValidFlag) {


### PR DESCRIPTION
This fixes the filename when exporting asserted assets system model.

e.g. "Test 1" is now  exported to "Test 1 asserted 2023-09-04T13_29.nq.gz"