### PR TITLE
Improve threats color scheme

### DIFF
--- a/src/main/webapp/app/modeller/components/panes/csgExplorer/ControlStrategyRenderer.js
+++ b/src/main/webapp/app/modeller/components/panes/csgExplorer/ControlStrategyRenderer.js
@@ -34,7 +34,8 @@ export function renderControlStrategy(csgName, controlStrategy, csgKey, threat, 
                 bsClass={"well well-sm strategy "
                 + (controlStrategy.enabled ? csgType === "BLOCK"
                     ? "enabled blocked" : csgType === "MITIGATE"
-                        ? "enabled mitigated" : "enabled" : "")}
+                        ? "enabled mitigated" : csgType === "TRIGGER"
+                            ? "enabled triggered" : "enabled" : "")}
                 >
                 {/*TODO: If MITIGATE is deprecated this conditional is unnecessary and can just be replaced with fa-star, or arguably no icon at all*/}
                 <p>

--- a/src/main/webapp/app/modeller/components/panes/details/accordion/panels/ThreatsPanel.js
+++ b/src/main/webapp/app/modeller/components/panes/details/accordion/panels/ThreatsPanel.js
@@ -629,7 +629,6 @@ class ThreatsPanel extends React.Component {
                 // TODO: put these colors and style in a stylesheet
                 symbol = <span className="fa fa-thumbs-up threat-icon" style={{backgroundColor: "red", color: "white"}}/>
             } else {
-                console.log(status, triggeredStatus);
                 if (triggeredStatus === "TRIGGERED") {
                     statusText += "Triggered";
                     threatClass = "triggered";

--- a/src/main/webapp/app/modeller/components/panes/details/accordion/panels/ThreatsPanel.js
+++ b/src/main/webapp/app/modeller/components/panes/details/accordion/panels/ThreatsPanel.js
@@ -645,7 +645,7 @@ class ThreatsPanel extends React.Component {
                 statusText = "Untriggered side effect";
                 emptyLevelTooltip = "This threat poses no risk as it has not been enabled by a control strategy";
                 symbol = <span className="fa fa-check threat-icon"/>;
-                threatClass = "blocked"; //clour as if blocked (e.g. green)
+                threatClass = "untriggered";
             }
 
             let root_cause = threat.rootCause;

--- a/src/main/webapp/app/modeller/components/panes/details/accordion/panels/ThreatsPanel.js
+++ b/src/main/webapp/app/modeller/components/panes/details/accordion/panels/ThreatsPanel.js
@@ -593,6 +593,7 @@ class ThreatsPanel extends React.Component {
             let statusText = "";
             let emptyLevelTooltip;
             let symbol;
+            let threatClass = "";
 
             /* Uncomment to add triggered state, e.g. for debugging
             if (triggeredStatus === "UNTRIGGERED") {
@@ -603,6 +604,10 @@ class ThreatsPanel extends React.Component {
             }
             */
 
+            if (triggeredStatus === "TRIGGERED") {
+                threatClass = "triggered";
+            }
+
             //Is threat a normal operation
             let normalOperation = threat.normalOperation !== undefined ? threat.normalOperation : false;
 
@@ -610,18 +615,29 @@ class ThreatsPanel extends React.Component {
                 // For now, display a blank icon here, as a space filler
                 // TODO: display a better icon here, e.g. depending on a "isAdverseOp" - see issue #107
                 symbol = <span className="threat-icon" style={{borderStyle: "none"}}></span>
+                threatClass = "normal";
             } else if (status === "BLOCKED") {
                 statusText += "Managed (" + threatColorAndBE.be.label + ")";
                 symbol = <span className="fa fa-check threat-icon" style={{backgroundColor: threatColorAndBE.color}}/>;
+                threatClass = "blocked";
             } else if (status === "MITIGATED") {
                 statusText += "Managed (" + threatColorAndBE.be.label + ")";
                 symbol = <span className="fa fa-minus threat-icon" style={{backgroundColor: threatColorAndBE.color}}/>;
+                threatClass = "mitigated";
             } else if (status === "ACCEPTED") {
                 statusText += "Accepted";
                 // TODO: put these colors and style in a stylesheet
                 symbol = <span className="fa fa-thumbs-up threat-icon" style={{backgroundColor: "red", color: "white"}}/>
             } else {
-                statusText += "Unmanaged";
+                console.log(status, triggeredStatus);
+                if (triggeredStatus === "TRIGGERED") {
+                    statusText += "Triggered";
+                    threatClass = "triggered";
+                }
+                else {
+                    statusText += "Unmanaged";
+                    threatClass = "unmanaged";
+                }
                 symbol = <span className="fa fa-exclamation-triangle threat-icon" style={{backgroundColor: "red", color: "white"}}/>;
             }
 
@@ -629,6 +645,7 @@ class ThreatsPanel extends React.Component {
                 statusText = "Untriggered side effect";
                 emptyLevelTooltip = "This threat poses no risk as it has not been enabled by a control strategy";
                 symbol = <span className="fa fa-check threat-icon"/>;
+                threatClass = "blocked"; //clour as if blocked (e.g. green)
             }
 
             let root_cause = threat.rootCause;
@@ -659,7 +676,7 @@ class ThreatsPanel extends React.Component {
 
             threatsRender.push(
                 <div key={index + 1} className={
-                    `row detail-info ${
+                    `row detail-info threat ${threatClass} ${
                         selected === true ? "selected-row" : "row-hover"
                     }`
                     }

--- a/src/main/webapp/app/modeller/components/panes/threats/ThreatEditor.js
+++ b/src/main/webapp/app/modeller/components/panes/threats/ThreatEditor.js
@@ -167,7 +167,7 @@ class ThreatEditor extends React.Component {
                     x: window.outerWidth * 0.25,
                     y: (100 / window.innerHeight) * window.devicePixelRatio,
                     width: 560,
-                    height: 700,
+                    height: 660,
                 }}
                 style={{ zIndex: this.props.windowOrder }}
                 minWidth={150}

--- a/src/main/webapp/app/modeller/index.scss
+++ b/src/main/webapp/app/modeller/index.scss
@@ -418,6 +418,9 @@ body {
     .clickable {
         color: black;
     }
+    .clickable:hover {
+        color: black;
+    }
     &.blocked {
         background-color: #a1e499;
     }
@@ -435,6 +438,27 @@ body {
     }
     &.unmanaged {
         background-color: #fea9a9;
+    }
+}
+
+.threat:hover {
+    &.blocked {
+        background-color: darken(#a1e499, 10%);
+    }
+    &.mitigated {
+        background-color: darken(#a1e499, 10%);
+    }
+    &.triggered {
+        background-color: darken(#f1d96b, 10%);
+    }
+    &.untriggered {
+        background-color: darken(#e4e4e4, 10%);
+    }
+    &.normal {
+        background-color: darken(#6ed1f8, 10%);
+    }
+    &.unmanaged {
+        background-color: darken(#fea9a9, 10%);
     }
 }
 

--- a/src/main/webapp/app/modeller/index.scss
+++ b/src/main/webapp/app/modeller/index.scss
@@ -350,8 +350,8 @@ body {
             div.well.well-sm {
                 &.strategy {
                     padding: 5px;
-                    background-color: #bcdbe4;
-                    border: 1px ridge #bcdbe4;
+                    background-color: #d5edf2;
+                    border: 1px ridge #d5edf2;
                     margin: 0;
                     overflow: hidden;
                     .optional {
@@ -359,15 +359,18 @@ body {
                     }
 
                     &.enabled {
-                        background-color: #a1e499;
-                        border: 1px ridge #bcdbe4;
+                        background-color: #6ed1f8;
+                        border: 1px ridge #6ed1f8;
                         margin: 0;
                         overflow: hidden;
                         &.blocked {
-                            background-color: #6ee461;
+                            background-color: #a1e499;
                         }
                         &.mitigated {
-                            background-color: #a2ee54;
+                            background-color: #a1e499;
+                        }
+                        &.triggered {
+                            background-color: #f1d96b;
                         }
                     }
                 }
@@ -407,6 +410,28 @@ body {
     }
     .ui-resizable-handle {
         cursor: nwse-resize;
+    }
+}
+
+.threat {
+    color: black;
+    .clickable {
+        color: black;
+    }
+    &.blocked {
+        background-color: #a1e499;
+    }
+    &.mitigated {
+        background-color: #a1e499;
+    }
+    &.triggered {
+        background-color: #f1d96b;
+    }
+    &.normal {
+        background-color: #6ed1f8;
+    }
+    &.unmanaged {
+        background-color: #fea9a9;
     }
 }
 

--- a/src/main/webapp/app/modeller/index.scss
+++ b/src/main/webapp/app/modeller/index.scss
@@ -427,6 +427,9 @@ body {
     &.triggered {
         background-color: #f1d96b;
     }
+    &.untriggered {
+        background-color: #e4e4e4;
+    }
     &.normal {
         background-color: #6ed1f8;
     }

--- a/src/main/webapp/app/modeller/index.scss
+++ b/src/main/webapp/app/modeller/index.scss
@@ -359,8 +359,8 @@ body {
                     }
 
                     &.enabled {
-                        background-color: #6ed1f8;
-                        border: 1px ridge #6ed1f8;
+                        background-color: #03b5fb;
+                        border: 1px ridge #03b5fb;
                         margin: 0;
                         overflow: hidden;
                         &.blocked {


### PR DESCRIPTION
This is a set of fixes to improve the color scheme of threats in the Threats list and Control Strategy Explorer. Threats are now coloured according to whether they are regular, normal operations, triggered, etc. See example below:

![image](https://github.com/Spyderisk/system-modeller/assets/50845365/70969592-befb-4fb3-9a64-9f925b145f4f)

Untriggered threats (not shown here) are coloured grey, to distinguish from blocked threats. The hover-over effect has also been improved.

