### PR TITLE
#193: Fixed style issue with additional properties panel

### DIFF
--- a/src/main/webapp/app/modeller/components/panes/details/accordion/panels/AdditionalPropertiesPanel.js
+++ b/src/main/webapp/app/modeller/components/panes/details/accordion/panels/AdditionalPropertiesPanel.js
@@ -337,7 +337,7 @@ class AdditionalPropertiesPanel extends React.Component {
 
         if (this.state.tableData.length > 0){
             return (
-                <table className="table table-hover table-sm table-condensed">
+                <table className="table table-hover table-sm table-condensed additionalProperties">
                     <thead className="thead-light">
                     <tr>
                         <th>Key</th>

--- a/src/main/webapp/app/modeller/index.scss
+++ b/src/main/webapp/app/modeller/index.scss
@@ -2120,3 +2120,20 @@ div.panel-title {
 .recommendations .bare-list {
     font-size: 14px;
 }
+
+table.additionalProperties {
+    table-layout: fixed;
+}
+
+table.additionalProperties td:nth-child(1),
+table.additionalProperties td:nth-child(2) {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+table.additionalProperties th:nth-child(3),
+table.additionalProperties th:nth-child(4) {
+    width: 20px;
+}
+    


### PR DESCRIPTION
If the key or value fields in the additional properties panel contained
a very long string, then this stopped the control icons at the end from
being accessible.
