### PR TITLE
Limits system CSG effectiveness level to be at most the coverage level

### DIFF
--- a/src/main/java/uk/ac/soton/itinnovation/security/modelvalidator/RiskCalculator.java
+++ b/src/main/java/uk/ac/soton/itinnovation/security/modelvalidator/RiskCalculator.java
@@ -1358,13 +1358,12 @@ public class RiskCalculator {
                 if(csg.isEnabled() && csg.getOptionalCS().isEmpty()){
                     ControlStrategyDB domainCSG = dcsgs.get(csg.getParent());
                     Integer domainCsgLevel = twLevels.get(domainCSG.getBlockingEffect()).getLevelValue();
-                    Integer csgCoverageLevel = twLevels.get(csg.getCoverageLevel()).getLevelValue();
-                    if (domainCsgLevel > maxCsgLevel) {
-                        maxCsgLevel = domainCsgLevel;
-                    }
+                    Integer csgCoverageLevel = twLevels.get(csg.getCoverageLevel()).getLevelValue();  // coverage level of mandatory controls
+                    Integer systemCsgLevel = Math.min(domainCsgLevel, csgCoverageLevel);  // system CSG TW is limited by the coverage level
+                    maxCsgLevel = Math.max(maxCsgLevel, systemCsgLevel);  // keep track of the most TW CSG
                 }
             }
-            maxLevel = maxLevel > maxCsgLevel ? maxLevel : maxCsgLevel;
+            maxLevel = Math.max(maxLevel, maxCsgLevel);
 
             // Convert to likelihood, and impose threat frequency limit if still above that limit
             LevelDB likelihood =  invertToLikelihood(trustworthinessLevels.get(maxLevel));


### PR DESCRIPTION
The `csgCoverageLevel` was being retrieved in the Risk Calculation, but nothing was done with the value (as highlighted by SonarLint actually). I've applied the value and made use of some `Math.max()` and `Math.min()` to tidy the code (in my opinion).