### PR TITLE
Update openAPI-3-schema.YAML

### DIFF
--- a/docs/openapi/openAPI-3-schema.YAML
+++ b/docs/openapi/openAPI-3-schema.YAML
@@ -12,7 +12,7 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
 - url: http://localhost:8089/system-modeller
-    description: Local server
+  description: Local server
 paths:
   /models/{modelid}:
     put:


### PR DESCRIPTION
The openAPI yaml does not parse the swagger editor (https://editor.swagger.io/) and throws the following error

```
Parser error 
bad indentation of a mapping entry
Jump to line 15
```

The description tag had the wrong indentiation

```
servers:
- url: http://localhost:8089/system-modeller
    description: Local server
```

and has been corrected

```
servers:
- url: http://localhost:8089/system-modeller
  description: Local server
```